### PR TITLE
Migrate idfFilePath to central method

### DIFF
--- a/OpenStudio_Adapter/CRUD/Create.cs
+++ b/OpenStudio_Adapter/CRUD/Create.cs
@@ -17,6 +17,7 @@ using BHC = BH.oM.Physical.Constructions;
 using BHEM = BH.oM.Environment.MaterialFragments;
 
 using BH.oM.Adapter;
+using BH.Engine.Adapter;
 
 namespace BH.Adapter.OpenStudio
 {
@@ -51,7 +52,7 @@ namespace BH.Adapter.OpenStudio
             EnergyPlusForwardTranslator translator = new EnergyPlusForwardTranslator();
             Workspace workspace = translator.translateModel(model);
             IdfFile idf = workspace.toIdfFile();
-            idf.save(global::OpenStudio.OpenStudioUtilitiesCore.toPath(m_IDFFilePath), true); //setting overwrite file true to avoid appending the surfaces to the exisiting idf file
+            idf.save(global::OpenStudio.OpenStudioUtilitiesCore.toPath(m_IDFFilePath.GetFullFileName()), true); //setting overwrite file true to avoid appending the surfaces to the exisiting idf file
 
             return success;
         }

--- a/OpenStudio_Adapter/OpenStudioAdapter.cs
+++ b/OpenStudio_Adapter/OpenStudioAdapter.cs
@@ -8,24 +8,30 @@ using BH.oM.Base;
 using BH.oM.Data.Requests;
 using BH.oM.Reflection.Attributes;
 using System.ComponentModel;
+using System.IO;
 
 namespace BH.Adapter.OpenStudio
 {
     public partial class OpenStudioAdapter : BHoMAdapter
     {
         [Description("Produces an OpenStudio Adapter to allow interopability with IDF files and the BHoM. This adapter is under development. Its use is not yet sanctioned for project work. You use this at your own risk. Check the GitHub repo for the latest version and updates on development status")]
-        [Input("idfFilePath", "Path to an IDF File")]
+        [Input("fileSettings", "Input file settings to get the path to an IDF File")]
         [Output("adapter", "Adapter to an IDF File")]
-        public OpenStudioAdapter(string idfFilePath)
+        public OpenStudioAdapter(BH.oM.Adapter.FileSettings fileSettings)
         {
             BH.Engine.Reflection.Compute.RecordWarning("This adapter is under development. Its use is not yet sanctioned for project work. You use this at your own risk. Check the GitHub repo for the latest version and updates on development status");
-            m_IDFFilePath = idfFilePath;
+            m_IDFFilePath = fileSettings;
+
+            if (!Path.HasExtension(fileSettings.FileName) || Path.GetExtension(fileSettings.FileName) != ".idf")
+            {
+                BH.Engine.Reflection.Compute.RecordError("File name must contain a file extension");
+            }
 
             AdapterIdName = "OpenStudio_Adapter";
 
             m_AdapterSettings.DefaultPushType = oM.Adapter.PushType.CreateOnly;
         }
 
-        private string m_IDFFilePath;
+        private BH.oM.Adapter.FileSettings m_IDFFilePath { get; set; } = null;
     }
 }

--- a/OpenStudio_Adapter/OpenStudio_Adapter.csproj
+++ b/OpenStudio_Adapter/OpenStudio_Adapter.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>BH.Adapter.OpenStudio</RootNamespace>
-    <AssemblyName>EnergyPlus_Adapter</AssemblyName>
+    <AssemblyName>OpenStudio_Adapter</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
@@ -32,6 +32,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Adapter_Engine">
+      <HintPath>..\..\BHoM_Adapter\Build\Adapter_Engine.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="Adapter_oM">
       <HintPath>..\..\BHoM_Adapter\Build\Adapter_oM.dll</HintPath>
     </Reference>
@@ -114,7 +118,6 @@
       <Name>OpenStudio_oM</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
     <PostBuildEvent>Copy /Y "$(ProjectDir)..\libs\msvcp120.dll" "$(ProjectDir)..\Build\msvcp120.dll"

--- a/OpenStudio_Engine/OpenStudio_Engine.csproj
+++ b/OpenStudio_Engine/OpenStudio_Engine.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>BH.Engine.OpenStudio</RootNamespace>
-    <AssemblyName>EnergyPlus_Engine</AssemblyName>
+    <AssemblyName>OpenStudio_Engine</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>

--- a/OpenStudio_oM/OpenStudio_oM.csproj
+++ b/OpenStudio_oM/OpenStudio_oM.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>BH.oM.OpenStudio</RootNamespace>
-    <AssemblyName>EnergyPlus_oM</AssemblyName>
+    <AssemblyName>OpenStudio_oM</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>


### PR DESCRIPTION

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #16 

The idfFilePath input for the adapter has been replaced by the fileSettings method in the Adapter_oM to get file name and directory for the adapter.

### Test files
<!-- Link to test files to validate the proposed changes -->


### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


### Additional comments
<!-- As required -->
