### PR TITLE
Corrected namespaces; corrected refs to Environment_Engine missing methods

### DIFF
--- a/OpenStudio_Adapter/CRUD/Create.cs
+++ b/OpenStudio_Adapter/CRUD/Create.cs
@@ -33,7 +33,7 @@ using BHE = BH.oM.Environment.Elements;
 using BHM = BH.oM.Physical.Materials;
 using BHP = BH.oM.Environment.Fragments;
 using BH.Engine.Environment;
-using BH.Engine.OpenStudio;
+using BH.Engine.Adapters.OpenStudio;
 
 using BHC = BH.oM.Physical.Constructions;
 using BHEM = BH.oM.Environment.MaterialFragments;

--- a/OpenStudio_Engine/Convert/Environment_oM/Building.cs
+++ b/OpenStudio_Engine/Convert/Environment_oM/Building.cs
@@ -29,7 +29,7 @@ using System.Threading.Tasks;
 using OpenStudio;
 using BHE = BH.oM.Environment.Elements;
 
-namespace BH.Engine.OpenStudio
+namespace BH.Engine.Adapters.OpenStudio
 {
     public static partial class Convert
     {

--- a/OpenStudio_Engine/Convert/Environment_oM/Construction.cs
+++ b/OpenStudio_Engine/Convert/Environment_oM/Construction.cs
@@ -31,7 +31,7 @@ using BHE = BH.oM.Environment.Elements;
 using BHM = BH.oM.Physical.Materials;
 using BHP = BH.oM.Physical.Constructions;
 
-namespace BH.Engine.OpenStudio
+namespace BH.Engine.Adapters.OpenStudio
 {
     public static partial class Convert
     {

--- a/OpenStudio_Engine/Convert/Environment_oM/Gas.cs
+++ b/OpenStudio_Engine/Convert/Environment_oM/Gas.cs
@@ -32,7 +32,7 @@ using BHG = BH.oM.Geometry;
 
 using BH.Engine.Environment;
 
-namespace BH.Engine.OpenStudio
+namespace BH.Engine.Adapters.OpenStudio
 {
     public static partial class Convert
     {

--- a/OpenStudio_Engine/Convert/Environment_oM/InternalGain.cs
+++ b/OpenStudio_Engine/Convert/Environment_oM/InternalGain.cs
@@ -25,17 +25,17 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using BH.oM.OpenStudio;
+using BH.oM.Adapters.OpenStudio;
 using OpenStudio;
 using BHE = BH.oM.Environment.Elements;
-using BH.oM.Environment.Gains;
+using BH.oM.Environment.SpaceCriteria;
 using BH.oM.Environment.Fragments;
 using System.ComponentModel;
 
 using BH.oM.Reflection.Attributes;
 using BH.Engine.Base;
 
-namespace BH.Engine.OpenStudio
+namespace BH.Engine.Adapters.OpenStudio
 {
     public static partial class Convert
     {
@@ -83,7 +83,7 @@ namespace BH.Engine.OpenStudio
         //[Input("InternalGain", "BHoM InternalGain")]
         //[Output("EnergyPlus InternalGain")]
 
-        public static global::OpenStudio.People ToOSMPeopleGain(this BH.oM.Environment.Gains.People peopleGain, global::OpenStudio.Model modelReference, global::OpenStudio.Space space)
+        public static global::OpenStudio.People ToOSMPeopleGain(this BH.oM.Environment.SpaceCriteria.People peopleGain, global::OpenStudio.Model modelReference, global::OpenStudio.Space space)
         {
             // TODO: remove static instance below for input of profile object instead!
             global::OpenStudio.ScheduleConstant activitySchedule = ToOSMScheduleConstantActivity(modelReference);
@@ -102,7 +102,7 @@ namespace BH.Engine.OpenStudio
             return osPeopleGain;
         }
 
-        public static global::OpenStudio.Lights ToOSMLightingGain(this BH.oM.Environment.Gains.Lighting lightGain, global::OpenStudio.Model modelReference, global::OpenStudio.Space space)
+        public static global::OpenStudio.Lights ToOSMLightingGain(this BH.oM.Environment.SpaceCriteria.Lighting lightGain, global::OpenStudio.Model modelReference, global::OpenStudio.Space space)
         {
             // TODO: remove static instance below for input of profile object instead!
             global::OpenStudio.ScheduleConstant lightingSchedule = ToOSMScheduleConstantsAlwaysOn(modelReference);
@@ -117,7 +117,7 @@ namespace BH.Engine.OpenStudio
             return lightingGain;
         }
 
-        public static global::OpenStudio.ElectricEquipment ToOSMEquipmentGain(this BH.oM.Environment.Gains.Equipment equipGain, global::OpenStudio.Model modelReference, global::OpenStudio.Space space)
+        public static global::OpenStudio.ElectricEquipment ToOSMEquipmentGain(this BH.oM.Environment.SpaceCriteria.Equipment equipGain, global::OpenStudio.Model modelReference, global::OpenStudio.Space space)
         {
             // TODO: remove static instance below for input of profile object instead!
             global::OpenStudio.ScheduleConstant equipmentSchedule = ToOSMScheduleConstantsAlwaysOn(modelReference);

--- a/OpenStudio_Engine/Convert/Environment_oM/Material.cs
+++ b/OpenStudio_Engine/Convert/Environment_oM/Material.cs
@@ -34,7 +34,7 @@ using BHEM = BH.oM.Environment.MaterialFragments;
 
 using BH.Engine.Environment;
 
-namespace BH.Engine.OpenStudio
+namespace BH.Engine.Adapters.OpenStudio
 {
     public static partial class Convert
     {

--- a/OpenStudio_Engine/Convert/Environment_oM/Opening.cs
+++ b/OpenStudio_Engine/Convert/Environment_oM/Opening.cs
@@ -35,7 +35,7 @@ using BH.Engine.Geometry;
 
 using BHG = BH.oM.Geometry;
 
-namespace BH.Engine.OpenStudio
+namespace BH.Engine.Adapters.OpenStudio
 {
     public static partial class Convert
     {

--- a/OpenStudio_Engine/Convert/Environment_oM/Panel.cs
+++ b/OpenStudio_Engine/Convert/Environment_oM/Panel.cs
@@ -34,7 +34,7 @@ using BH.Engine.Environment;
 using BHG = BH.oM.Geometry;
 using BH.Engine.Geometry;
 
-namespace BH.Engine.OpenStudio
+namespace BH.Engine.Adapters.OpenStudio
 {
     public static partial class Convert
     {
@@ -66,7 +66,8 @@ namespace BH.Engine.OpenStudio
                 else
                     newOpeningBounds.Add(panel.Polyline());
 
-                BHE.Opening curtainWallOpening = BH.Engine.Environment.Create.Opening(externalEdges: BH.Engine.Geometry.Create.PolyCurve(newOpeningBounds).ICollapseToPolyline(BH.oM.Geometry.Tolerance.Angle).ToEdges());
+                BHE.Opening curtainWallOpening = new BHE.Opening() { Edges = BH.Engine.Geometry.Create.PolyCurve(newOpeningBounds).ICollapseToPolyline(BH.oM.Geometry.Tolerance.Angle).ToEdges() };
+
                 //Scale the bounding curve to comply with IDF rules
                 BHG.Polyline crv = curtainWallOpening.Polyline();
                 curtainWallOpening.Edges = crv.Scale(crv.Centre(), BH.Engine.Geometry.Create.Vector(0.95, 0.95, 0.95)).ToEdges();

--- a/OpenStudio_Engine/Convert/Environment_oM/PanelType.cs
+++ b/OpenStudio_Engine/Convert/Environment_oM/PanelType.cs
@@ -28,7 +28,7 @@ using System.Threading.Tasks;
 
 using BHE = BH.oM.Environment.Elements;
 
-namespace BH.Engine.OpenStudio
+namespace BH.Engine.Adapters.OpenStudio
 {
     public static partial class Convert
     {

--- a/OpenStudio_Engine/Convert/Environment_oM/Roughness.cs
+++ b/OpenStudio_Engine/Convert/Environment_oM/Roughness.cs
@@ -33,7 +33,7 @@ using BHM = BH.oM.Environment.MaterialFragments;
 
 using BH.Engine.Environment;
 
-namespace BH.Engine.OpenStudio
+namespace BH.Engine.Adapters.OpenStudio
 {
     public static partial class Convert
     {

--- a/OpenStudio_Engine/Convert/Environment_oM/Zone.cs
+++ b/OpenStudio_Engine/Convert/Environment_oM/Zone.cs
@@ -29,7 +29,7 @@ using System.Threading.Tasks;
 using OpenStudio;
 using BHE = BH.oM.Environment.Elements;
 
-namespace BH.Engine.OpenStudio
+namespace BH.Engine.Adapters.OpenStudio
 {
     public static partial class Convert
     {   

--- a/OpenStudio_Engine/Convert/Geometry_oM/ICurve.cs
+++ b/OpenStudio_Engine/Convert/Geometry_oM/ICurve.cs
@@ -29,7 +29,7 @@ using System.Threading.Tasks;
 using BHG = BH.oM.Geometry;
 using OpenStudio;
 
-namespace BH.Engine.OpenStudio
+namespace BH.Engine.Adapters.OpenStudio
 {
     public static partial class Convert
     {

--- a/OpenStudio_Engine/Convert/Geometry_oM/Point.cs
+++ b/OpenStudio_Engine/Convert/Geometry_oM/Point.cs
@@ -29,7 +29,7 @@ using System.Threading.Tasks;
 using OpenStudio;
 using BHG = BH.oM.Geometry;
 
-namespace BH.Engine.OpenStudio
+namespace BH.Engine.Adapters.OpenStudio
 {
     public static partial class Convert
     {

--- a/OpenStudio_Engine/Convert/Geometry_oM/Polycurve.cs
+++ b/OpenStudio_Engine/Convert/Geometry_oM/Polycurve.cs
@@ -30,7 +30,7 @@ using OpenStudio;
 using BHG = BH.oM.Geometry;
 using BH.Engine.Geometry;
 
-namespace BH.Engine.OpenStudio
+namespace BH.Engine.Adapters.OpenStudio
 {
     public static partial class Convert
     {

--- a/OpenStudio_Engine/Convert/Geometry_oM/Polyline.cs
+++ b/OpenStudio_Engine/Convert/Geometry_oM/Polyline.cs
@@ -29,7 +29,7 @@ using System.Threading.Tasks;
 using OpenStudio;
 using BHG = BH.oM.Geometry;
 
-namespace BH.Engine.OpenStudio
+namespace BH.Engine.Adapters.OpenStudio
 {
     public static partial class Convert
     {

--- a/OpenStudio_Engine/Create/DesignSpecificationOutdoorAir.cs
+++ b/OpenStudio_Engine/Create/DesignSpecificationOutdoorAir.cs
@@ -28,10 +28,10 @@ using System.Threading.Tasks;
 using System.ComponentModel;
 
 using BH.oM.Reflection.Attributes;
-using BH.oM.OpenStudio;
+using BH.oM.Adapters.OpenStudio;
 using BH.Engine.Base;
 
-namespace BH.Engine.OpenStudio
+namespace BH.Engine.Adapters.OpenStudio
 {
     //public static partial class Create
     //{

--- a/OpenStudio_Engine/Create/HVACTemplateThermostat.cs
+++ b/OpenStudio_Engine/Create/HVACTemplateThermostat.cs
@@ -28,10 +28,10 @@ using System.Threading.Tasks;
 using System.ComponentModel;
 
 using BH.oM.Reflection.Attributes;
-using BH.oM.OpenStudio;
+using BH.oM.Adapters.OpenStudio;
 using BH.Engine.Base;
 
-namespace BH.Engine.OpenStudio
+namespace BH.Engine.Adapters.OpenStudio
 {
     //public static partial class Create
     //{

--- a/OpenStudio_Engine/Create/HVACTemplateZoneIdealLoadsAirSystem.cs
+++ b/OpenStudio_Engine/Create/HVACTemplateZoneIdealLoadsAirSystem.cs
@@ -28,10 +28,10 @@ using System.Threading.Tasks;
 using System.ComponentModel;
 
 using BH.oM.Reflection.Attributes;
-using BH.oM.OpenStudio;
+using BH.oM.Adapters.OpenStudio;
 using BH.Engine.Base;
 
-namespace BH.Engine.OpenStudio
+namespace BH.Engine.Adapters.OpenStudio
 {
     //public static partial class Create
     //{

--- a/OpenStudio_Engine/Create/HeatBalanceAlgorithm.cs
+++ b/OpenStudio_Engine/Create/HeatBalanceAlgorithm.cs
@@ -28,10 +28,10 @@ using System.Threading.Tasks;
 using System.ComponentModel;
 
 using BH.oM.Reflection.Attributes;
-using BH.oM.OpenStudio;
+using BH.oM.Adapters.OpenStudio;
 using BH.Engine.Base;
 
-namespace BH.Engine.OpenStudio
+namespace BH.Engine.Adapters.OpenStudio
 {
     //public static partial class Create
     //{

--- a/OpenStudio_Engine/Create/HeatBalanceSettingsConductionFiniteDifference.cs
+++ b/OpenStudio_Engine/Create/HeatBalanceSettingsConductionFiniteDifference.cs
@@ -28,10 +28,10 @@ using System.Threading.Tasks;
 using System.ComponentModel;
 
 using BH.oM.Reflection.Attributes;
-using BH.oM.OpenStudio;
+using BH.oM.Adapters.OpenStudio;
 using BH.Engine.Base;
 
-namespace BH.Engine.OpenStudio
+namespace BH.Engine.Adapters.OpenStudio
 {
     //public static partial class Create
     //{

--- a/OpenStudio_Engine/Create/OutputVariable.cs
+++ b/OpenStudio_Engine/Create/OutputVariable.cs
@@ -28,10 +28,10 @@ using System.Threading.Tasks;
 using System.ComponentModel;
 
 using BH.oM.Reflection.Attributes;
-using BH.oM.OpenStudio;
+using BH.oM.Adapters.OpenStudio;
 using BH.Engine.Base;
 
-namespace BH.Engine.OpenStudio
+namespace BH.Engine.Adapters.OpenStudio
 {
     //public static partial class Create
     //{

--- a/OpenStudio_Engine/Create/Runperiod.cs
+++ b/OpenStudio_Engine/Create/Runperiod.cs
@@ -27,13 +27,13 @@ using System.Text;
 using System.Threading.Tasks;
 
 using BH.oM.Reflection.Attributes;
-using BH.oM.OpenStudio;
+using BH.oM.Adapters.OpenStudio;
 using BH.Engine.Base;
 using System.Collections;
 using System.ComponentModel;
 using BH.oM.Environment.Elements;
 
-namespace BH.Engine.OpenStudio
+namespace BH.Engine.Adapters.OpenStudio
 {
     //public static partial class Create
     //{

--- a/OpenStudio_Engine/Create/ScheduleFile.cs
+++ b/OpenStudio_Engine/Create/ScheduleFile.cs
@@ -28,10 +28,10 @@ using System.Threading.Tasks;
 using System.ComponentModel;
 
 using BH.oM.Reflection.Attributes;
-using BH.oM.OpenStudio;
+using BH.oM.Adapters.OpenStudio;
 using BH.Engine.Base;
 
-namespace BH.Engine.OpenStudio
+namespace BH.Engine.Adapters.OpenStudio
 {
     //public static partial class Create
     //{

--- a/OpenStudio_Engine/Create/ShadowCalculation.cs
+++ b/OpenStudio_Engine/Create/ShadowCalculation.cs
@@ -27,13 +27,13 @@ using System.Text;
 using System.Threading.Tasks;
 
 using BH.oM.Reflection.Attributes;
-using BH.oM.OpenStudio;
+using BH.oM.Adapters.OpenStudio;
 using BH.Engine.Base;
 
 using System.Collections;
 using System.ComponentModel;
 
-namespace BH.Engine.OpenStudio
+namespace BH.Engine.Adapters.OpenStudio
 {
     //public static partial class Create
     //{

--- a/OpenStudio_Engine/Create/SimulationControl.cs
+++ b/OpenStudio_Engine/Create/SimulationControl.cs
@@ -28,10 +28,10 @@ using System.Threading.Tasks;
 using System.ComponentModel;
 
 using BH.oM.Reflection.Attributes;
-using BH.oM.OpenStudio;
+using BH.oM.Adapters.OpenStudio;
 using BH.Engine.Base;
 
-namespace BH.Engine.OpenStudio
+namespace BH.Engine.Adapters.OpenStudio
 {
     //public static partial class Create
     //{

--- a/OpenStudio_Engine/Create/SurfaceConvectionAlgorithmInside.cs
+++ b/OpenStudio_Engine/Create/SurfaceConvectionAlgorithmInside.cs
@@ -28,10 +28,10 @@ using System.Threading.Tasks;
 using System.ComponentModel;
 
 using BH.oM.Reflection.Attributes;
-using BH.oM.OpenStudio;
+using BH.oM.Adapters.OpenStudio;
 using BH.Engine.Base;
 
-namespace BH.Engine.OpenStudio
+namespace BH.Engine.Adapters.OpenStudio
 {
     //public static partial class Create
     //{

--- a/OpenStudio_Engine/Create/SurfaceConvectionAlgorithmOutside.cs
+++ b/OpenStudio_Engine/Create/SurfaceConvectionAlgorithmOutside.cs
@@ -28,10 +28,10 @@ using System.Threading.Tasks;
 using System.ComponentModel;
 
 using BH.oM.Reflection.Attributes;
-using BH.oM.OpenStudio;
+using BH.oM.Adapters.OpenStudio;
 using BH.Engine.Base;
 
-namespace BH.Engine.OpenStudio
+namespace BH.Engine.Adapters.OpenStudio
 {
     //public static partial class Create
     //{

--- a/OpenStudio_Engine/Create/TimeStep.cs
+++ b/OpenStudio_Engine/Create/TimeStep.cs
@@ -28,10 +28,10 @@ using System.Threading.Tasks;
 using System.ComponentModel;
 
 using BH.oM.Reflection.Attributes;
-using BH.oM.OpenStudio;
+using BH.oM.Adapters.OpenStudio;
 using BH.Engine.Base;
 
-namespace BH.Engine.OpenStudio
+namespace BH.Engine.Adapters.OpenStudio
 {
     //public static partial class Create
     //{

--- a/OpenStudio_Engine/Create/ZoneAirHeatBalanceAlgorithm.cs
+++ b/OpenStudio_Engine/Create/ZoneAirHeatBalanceAlgorithm.cs
@@ -28,10 +28,10 @@ using System.Threading.Tasks;
 using System.ComponentModel;
 
 using BH.oM.Reflection.Attributes;
-using BH.oM.OpenStudio;
+using BH.oM.Adapters.OpenStudio;
 using BH.Engine.Base;
 
-namespace BH.Engine.OpenStudio
+namespace BH.Engine.Adapters.OpenStudio
 {
     //public static partial class Create
     //{

--- a/OpenStudio_Engine/Modify/OffsetOpening.cs
+++ b/OpenStudio_Engine/Modify/OffsetOpening.cs
@@ -34,7 +34,7 @@ using BH.oM.Reflection.Attributes;
 using System.ComponentModel;
 using BH.Engine.Environment;
 
-namespace BH.Engine.OpenStudio
+namespace BH.Engine.Adapters.OpenStudio
 {
     public static partial class Modify
     {
@@ -88,8 +88,8 @@ namespace BH.Engine.OpenStudio
                         List<BH.oM.Geometry.Point> polyPoints = openingPolyCurve.IDiscontinuityPoints();
                         BH.oM.Geometry.Polyline openingPolyLine = BH.Engine.Geometry.Create.Polyline(polyPoints);                        
                         Polyline offsetPolyline = Geometry.Modify.Offset(openingPolyLine, distance);
-                        List<BHE.Edge> edges = offsetPolyline.ToEdges().ToList();                      
-                        BHE.Opening newOpening = BH.Engine.Environment.Create.Opening("name", edges);
+                        List<BHE.Edge> edges = offsetPolyline.ToEdges().ToList();
+                        BHE.Opening newOpening = new BHE.Opening() { Edges = edges };
                         panel.Openings.Add(newOpening);                                               
                     }
                     return panel;

--- a/OpenStudio_Engine/OpenStudio_Engine.csproj
+++ b/OpenStudio_Engine/OpenStudio_Engine.csproj
@@ -7,7 +7,7 @@
     <ProjectGuid>{81801312-9164-4C58-B78F-A2F7E41C351A}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>BH.Engine.OpenStudio</RootNamespace>
+    <RootNamespace>BH.Engine.Adapters.OpenStudio</RootNamespace>
     <AssemblyName>OpenStudio_Engine</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>

--- a/OpenStudio_Engine/Query/OutsideBoundaryCondition.cs
+++ b/OpenStudio_Engine/Query/OutsideBoundaryCondition.cs
@@ -34,7 +34,7 @@ using BH.Engine.Environment;
 using BHG = BH.oM.Geometry;
 using BH.Engine.Geometry;
 
-namespace BH.Engine.OpenStudio
+namespace BH.Engine.Adapters.OpenStudio
 {
     public static partial class Query
     {

--- a/OpenStudio_oM/AirNode.cs
+++ b/OpenStudio_oM/AirNode.cs
@@ -27,7 +27,7 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Base;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     //public class AirNode : BHoMObject
     //{

--- a/OpenStudio_oM/Enums/HVACDesignObjects.cs
+++ b/OpenStudio_oM/Enums/HVACDesignObjects.cs
@@ -26,7 +26,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     public enum OutdoorAirMethodType
     {

--- a/OpenStudio_oM/Enums/HVACTemplates.cs
+++ b/OpenStudio_oM/Enums/HVACTemplates.cs
@@ -26,7 +26,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     public enum HeatingCoolingLimitType
     {

--- a/OpenStudio_oM/Enums/InternalGains.cs
+++ b/OpenStudio_oM/Enums/InternalGains.cs
@@ -26,7 +26,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     public enum ElectricEquipmentDesignLevelCalculationMethodType
     {

--- a/OpenStudio_oM/Enums/LocationandClimate.cs
+++ b/OpenStudio_oM/Enums/LocationandClimate.cs
@@ -26,7 +26,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     public enum SolarModelIndicatorType
     {

--- a/OpenStudio_oM/Enums/MaterialEnums.cs
+++ b/OpenStudio_oM/Enums/MaterialEnums.cs
@@ -26,7 +26,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     public enum WindowMaterialGasType
     {

--- a/OpenStudio_oM/Enums/NodeBranchManagement.cs
+++ b/OpenStudio_oM/Enums/NodeBranchManagement.cs
@@ -26,7 +26,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     public enum WindAngleType
     {

--- a/OpenStudio_oM/Enums/OutputReporting.cs
+++ b/OpenStudio_oM/Enums/OutputReporting.cs
@@ -26,7 +26,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     public enum OutputVariableDictionarySortOptionType
     {

--- a/OpenStudio_oM/Enums/Schedules.cs
+++ b/OpenStudio_oM/Enums/Schedules.cs
@@ -26,7 +26,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     public enum NumericType
     {

--- a/OpenStudio_oM/Enums/SimulationParameters.cs
+++ b/OpenStudio_oM/Enums/SimulationParameters.cs
@@ -26,7 +26,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     // All algorithms referenced here can be found in documentation for EnergyPlus - https://bigladdersoftware.com/epx/docs/8-0/engineering-reference/page-021.html
 

--- a/OpenStudio_oM/Enums/ThermalZonesandSurfaces.cs
+++ b/OpenStudio_oM/Enums/ThermalZonesandSurfaces.cs
@@ -26,7 +26,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     public enum WindowPropertyDividerType
     {

--- a/OpenStudio_oM/Enums/ZoneAirflow.cs
+++ b/OpenStudio_oM/Enums/ZoneAirflow.cs
@@ -26,7 +26,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     public enum VentilationType
     {

--- a/OpenStudio_oM/Enums/ZoneHVACForcedAirUnits.cs
+++ b/OpenStudio_oM/Enums/ZoneHVACForcedAirUnits.cs
@@ -26,7 +26,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     public enum CapacityControlMethodType
     {

--- a/OpenStudio_oM/HVACDesignObjects/DesignSpecificationOutdoorAir.cs
+++ b/OpenStudio_oM/HVACDesignObjects/DesignSpecificationOutdoorAir.cs
@@ -27,7 +27,7 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Base;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     //public class DesignSpecificationOutdoorAir : BHoMObject
     //{

--- a/OpenStudio_oM/HVACDesignObjects/SizingParameters.cs
+++ b/OpenStudio_oM/HVACDesignObjects/SizingParameters.cs
@@ -27,7 +27,7 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Base;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     //public class SizingParameters : BHoMObject
     //{

--- a/OpenStudio_oM/HVACTemplates/HVACTemplateThermostat.cs
+++ b/OpenStudio_oM/HVACTemplates/HVACTemplateThermostat.cs
@@ -27,7 +27,7 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Base;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     //public class HVACTemplateThermostat : BHoMObject
     //{

--- a/OpenStudio_oM/HVACTemplates/HVACTemplateZoneIdealLoadsAirSystem.cs
+++ b/OpenStudio_oM/HVACTemplates/HVACTemplateZoneIdealLoadsAirSystem.cs
@@ -27,7 +27,7 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Base;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     //public class HVACTemplateZoneIdealLoadsAirSystem : BHoMObject
     //{

--- a/OpenStudio_oM/ISchedule.cs
+++ b/OpenStudio_oM/ISchedule.cs
@@ -28,7 +28,7 @@ using System.Threading.Tasks;
 
 using BH.oM.Base;
 
-namespace BH.oM.OpenStudio.Interface
+namespace BH.oM.Adapters.OpenStudio.Interface
 {
     //public interface IScheduleDay : IBHoMObject
     //{

--- a/OpenStudio_oM/InternalGains/ElectricEquipment.cs
+++ b/OpenStudio_oM/InternalGains/ElectricEquipment.cs
@@ -26,9 +26,9 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Base;
-using BH.oM.OpenStudio.Interface;
+using BH.oM.Adapters.OpenStudio.Interface;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     //public class ElectricEquipment : BHoMObject
     //{

--- a/OpenStudio_oM/InternalGains/Lights.cs
+++ b/OpenStudio_oM/InternalGains/Lights.cs
@@ -26,9 +26,9 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Base;
-using BH.oM.OpenStudio.Interface;
+using BH.oM.Adapters.OpenStudio.Interface;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     //public class Lights : BHoMObject
     //{

--- a/OpenStudio_oM/InternalGains/People.cs
+++ b/OpenStudio_oM/InternalGains/People.cs
@@ -27,7 +27,7 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Base;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     //public class People : BHoMObject
     //{

--- a/OpenStudio_oM/LocationandClimate/RunPeriod.cs
+++ b/OpenStudio_oM/LocationandClimate/RunPeriod.cs
@@ -27,7 +27,7 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Base;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     //public class RunPeriod : BHoMObject
     //{

--- a/OpenStudio_oM/LocationandClimate/SiteLocation.cs
+++ b/OpenStudio_oM/LocationandClimate/SiteLocation.cs
@@ -27,7 +27,7 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Base;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     //public class SiteLocation : BHoMObject
     //{

--- a/OpenStudio_oM/LocationandClimate/SizingPeriodDesignDay.cs
+++ b/OpenStudio_oM/LocationandClimate/SizingPeriodDesignDay.cs
@@ -26,9 +26,9 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Base;
-using BH.oM.OpenStudio.Interface;
+using BH.oM.Adapters.OpenStudio.Interface;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     //public class SizingPeriodDesignDay : BHoMObject
     //{

--- a/OpenStudio_oM/NaturalVentilationandDuctLeakage/AirflowNetworkDistributionNode.cs
+++ b/OpenStudio_oM/NaturalVentilationandDuctLeakage/AirflowNetworkDistributionNode.cs
@@ -26,7 +26,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     //class AirflowNetworkDistributionNode
     //{

--- a/OpenStudio_oM/NodeBranchManagement/OutdoorAirNode.cs
+++ b/OpenStudio_oM/NodeBranchManagement/OutdoorAirNode.cs
@@ -26,7 +26,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     //class OutdoorAirNode
     //{

--- a/OpenStudio_oM/OpenStudio_oM.csproj
+++ b/OpenStudio_oM/OpenStudio_oM.csproj
@@ -7,7 +7,7 @@
     <ProjectGuid>{3AE8A451-F426-4094-A5B8-86F1944D7B38}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>BH.oM.OpenStudio</RootNamespace>
+    <RootNamespace>BH.oM.Adatpers.OpenStudio</RootNamespace>
     <AssemblyName>OpenStudio_oM</AssemblyName>
     <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>

--- a/OpenStudio_oM/OutputReporting/OutputConstructions.cs
+++ b/OpenStudio_oM/OutputReporting/OutputConstructions.cs
@@ -27,7 +27,7 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Base;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     //public class OutputConstructions : BHoMObject
     //{

--- a/OpenStudio_oM/OutputReporting/OutputControlTableStyle.cs
+++ b/OpenStudio_oM/OutputReporting/OutputControlTableStyle.cs
@@ -27,7 +27,7 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Base;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     //public class OutputControlTableStyle : BHoMObject
     //{

--- a/OpenStudio_oM/OutputReporting/OutputDebuggingData.cs
+++ b/OpenStudio_oM/OutputReporting/OutputDebuggingData.cs
@@ -27,7 +27,7 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Base;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     //public class OutputDebuggingData : BHoMObject
     //{

--- a/OpenStudio_oM/OutputReporting/OutputDiagnostics.cs
+++ b/OpenStudio_oM/OutputReporting/OutputDiagnostics.cs
@@ -27,7 +27,7 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Base;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     //public class OutputDiagnostics : BHoMObject
     //{

--- a/OpenStudio_oM/OutputReporting/OutputSurfacesDrawing.cs
+++ b/OpenStudio_oM/OutputReporting/OutputSurfacesDrawing.cs
@@ -27,7 +27,7 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Base;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     //public class OutputSurfacesDrawing : BHoMObject
     //{

--- a/OpenStudio_oM/OutputReporting/OutputSurfacesList.cs
+++ b/OpenStudio_oM/OutputReporting/OutputSurfacesList.cs
@@ -27,7 +27,7 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Base;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     //public class OutputSurfacesList : BHoMObject
     //{

--- a/OpenStudio_oM/OutputReporting/OutputVariable.cs
+++ b/OpenStudio_oM/OutputReporting/OutputVariable.cs
@@ -27,7 +27,7 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Base;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     //public class OutputVariable : BHoMObject
     //{

--- a/OpenStudio_oM/OutputReporting/OutputVariableDictionary.cs
+++ b/OpenStudio_oM/OutputReporting/OutputVariableDictionary.cs
@@ -27,7 +27,7 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Base;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     //public class OutputVariableDictionary : BHoMObject
     //{

--- a/OpenStudio_oM/Schedules/ScheduleDayHourly.cs
+++ b/OpenStudio_oM/Schedules/ScheduleDayHourly.cs
@@ -26,9 +26,9 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Base;
-using BH.oM.OpenStudio.Interface;
+using BH.oM.Adapters.OpenStudio.Interface;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     //public class ScheduleDayHourly : BHoMObject, IScheduleDay
     //{

--- a/OpenStudio_oM/Schedules/ScheduleDayInterval.cs
+++ b/OpenStudio_oM/Schedules/ScheduleDayInterval.cs
@@ -26,9 +26,9 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Base;
-using BH.oM.OpenStudio.Interface;
+using BH.oM.Adapters.OpenStudio.Interface;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     //public class ScheduleDayInterval : BHoMObject, IScheduleDay
     //{

--- a/OpenStudio_oM/Schedules/ScheduleFile.cs
+++ b/OpenStudio_oM/Schedules/ScheduleFile.cs
@@ -27,7 +27,7 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Base;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     //public class ScheduleFile : BHoMObject
     //{

--- a/OpenStudio_oM/Schedules/ScheduleTypeLimits.cs
+++ b/OpenStudio_oM/Schedules/ScheduleTypeLimits.cs
@@ -27,7 +27,7 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Base;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     //public class ScheduleTypeLimits : BHoMObject
     //{

--- a/OpenStudio_oM/Schedules/ScheduleWeekDaily.cs
+++ b/OpenStudio_oM/Schedules/ScheduleWeekDaily.cs
@@ -26,9 +26,9 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Base;
-using BH.oM.OpenStudio.Interface;
+using BH.oM.Adapters.OpenStudio.Interface;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     //public class ScheduleWeekDaily : BHoMObject, IScheduleWeek
     //{

--- a/OpenStudio_oM/Schedules/ScheduleYear.cs
+++ b/OpenStudio_oM/Schedules/ScheduleYear.cs
@@ -27,7 +27,7 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Base;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     //public class ScheduleYear : BHoMObject
     //{

--- a/OpenStudio_oM/Schedules/ScheduleYearVal.cs
+++ b/OpenStudio_oM/Schedules/ScheduleYearVal.cs
@@ -26,9 +26,9 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Base;
-using BH.oM.OpenStudio.Interface;
+using BH.oM.Adapters.OpenStudio.Interface;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     //public class ScheduleYearVal : BHoMObject
     //{

--- a/OpenStudio_oM/Schedules/TimeValue.cs
+++ b/OpenStudio_oM/Schedules/TimeValue.cs
@@ -26,9 +26,9 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Base;
-using BH.oM.OpenStudio.Interface;
+using BH.oM.Adapters.OpenStudio.Interface;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     //public class TimeValue : BHoMObject
     //{

--- a/OpenStudio_oM/SimulationParameters/Building.cs
+++ b/OpenStudio_oM/SimulationParameters/Building.cs
@@ -27,7 +27,7 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Base;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     //public class Building : BHoMObject
     //{

--- a/OpenStudio_oM/SimulationParameters/HeatBalanceAlgorithm.cs
+++ b/OpenStudio_oM/SimulationParameters/HeatBalanceAlgorithm.cs
@@ -27,7 +27,7 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Base;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     //public class HeatBalanceAlgorithm : BHoMObject
     //{

--- a/OpenStudio_oM/SimulationParameters/HeatBalanceSettingsConductionFiniteDifference.cs
+++ b/OpenStudio_oM/SimulationParameters/HeatBalanceSettingsConductionFiniteDifference.cs
@@ -27,7 +27,7 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Base;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     //public class HeatBalanceSettingsConductionFiniteDifference : BHoMObject
     //{

--- a/OpenStudio_oM/SimulationParameters/ShadowCalculation.cs
+++ b/OpenStudio_oM/SimulationParameters/ShadowCalculation.cs
@@ -27,7 +27,7 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Base;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     //public class ShadowCalculation : BHoMObject
     //{

--- a/OpenStudio_oM/SimulationParameters/SimulationControl.cs
+++ b/OpenStudio_oM/SimulationParameters/SimulationControl.cs
@@ -27,7 +27,7 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Base;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     //public class SimulationControl : BHoMObject
     //{

--- a/OpenStudio_oM/SimulationParameters/SurfaceConvectionAlgorithmInside.cs
+++ b/OpenStudio_oM/SimulationParameters/SurfaceConvectionAlgorithmInside.cs
@@ -27,7 +27,7 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Base;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     //public class SurfaceConvectionAlgorithmInside : BHoMObject
     //{

--- a/OpenStudio_oM/SimulationParameters/SurfaceConvectionAlgorithmOutside.cs
+++ b/OpenStudio_oM/SimulationParameters/SurfaceConvectionAlgorithmOutside.cs
@@ -27,7 +27,7 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Base;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     //public class SurfaceConvectionAlgorithmOutside : BHoMObject
     //{

--- a/OpenStudio_oM/SimulationParameters/Timestep.cs
+++ b/OpenStudio_oM/SimulationParameters/Timestep.cs
@@ -27,7 +27,7 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Base;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     //public class Timestep : BHoMObject
     //{

--- a/OpenStudio_oM/SimulationParameters/Version.cs
+++ b/OpenStudio_oM/SimulationParameters/Version.cs
@@ -27,7 +27,7 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Base;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     //public class Version : BHoMObject
     //{

--- a/OpenStudio_oM/SimulationParameters/ZoneAirHeatBalanceAlgorithm.cs
+++ b/OpenStudio_oM/SimulationParameters/ZoneAirHeatBalanceAlgorithm.cs
@@ -27,7 +27,7 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Base;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     //public class ZoneAirHeatBalanceAlgorithm : BHoMObject
     //{

--- a/OpenStudio_oM/SimulationParameters/ZoneAirMassFlowConservation.cs
+++ b/OpenStudio_oM/SimulationParameters/ZoneAirMassFlowConservation.cs
@@ -27,7 +27,7 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Base;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     //public class ZoneAirMassFlowConservation : BHoMObject
     //{

--- a/OpenStudio_oM/ThermalZonesandSurfaces/BuildingSurfaceDetailed.cs
+++ b/OpenStudio_oM/ThermalZonesandSurfaces/BuildingSurfaceDetailed.cs
@@ -28,7 +28,7 @@ using System.Threading.Tasks;
 using BH.oM.Base;
 using BH.oM.Geometry;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     //public class BuildingSurfaceDetailed : BHoMObject
     //{

--- a/OpenStudio_oM/ThermalZonesandSurfaces/FenestrationSurfaceDetailed.cs
+++ b/OpenStudio_oM/ThermalZonesandSurfaces/FenestrationSurfaceDetailed.cs
@@ -28,7 +28,7 @@ using System.Threading.Tasks;
 using BH.oM.Base;
 using BH.oM.Geometry;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     //public class FenestrationSurfaceDetailed : BHoMObject
     //{

--- a/OpenStudio_oM/ThermalZonesandSurfaces/GlobalGeometryRules.cs
+++ b/OpenStudio_oM/ThermalZonesandSurfaces/GlobalGeometryRules.cs
@@ -27,7 +27,7 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Base;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     //public class GlobalGeometryRules : BHoMObject
     //{

--- a/OpenStudio_oM/ThermalZonesandSurfaces/ShadingBuildingDetailed.cs
+++ b/OpenStudio_oM/ThermalZonesandSurfaces/ShadingBuildingDetailed.cs
@@ -28,7 +28,7 @@ using System.Threading.Tasks;
 using BH.oM.Base;
 using BH.oM.Geometry;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     //public class ShadingBuildingDetailed : BHoMObject
     //{

--- a/OpenStudio_oM/ThermalZonesandSurfaces/WindowPropertyFrameAndDivider.cs
+++ b/OpenStudio_oM/ThermalZonesandSurfaces/WindowPropertyFrameAndDivider.cs
@@ -27,7 +27,7 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Base;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     //public class WindowPropertyFrameAndDivider : BHoMObject
     //{

--- a/OpenStudio_oM/ThermalZonesandSurfaces/Zone.cs
+++ b/OpenStudio_oM/ThermalZonesandSurfaces/Zone.cs
@@ -27,7 +27,7 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Base;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     //public class Zone : BHoMObject
     //{

--- a/OpenStudio_oM/ZoneAirflow/ZoneInfiltrationDesignFlowRate.cs
+++ b/OpenStudio_oM/ZoneAirflow/ZoneInfiltrationDesignFlowRate.cs
@@ -27,7 +27,7 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Base;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     //public class ZoneInfiltrationDesignFlowRate : BHoMObject
     //{

--- a/OpenStudio_oM/ZoneAirflow/ZoneMixing.cs
+++ b/OpenStudio_oM/ZoneAirflow/ZoneMixing.cs
@@ -27,7 +27,7 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Base;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     //public class ZoneMixing : BHoMObject
     //{

--- a/OpenStudio_oM/ZoneAirflow/ZoneVentilationDesignFlowRate.cs
+++ b/OpenStudio_oM/ZoneAirflow/ZoneVentilationDesignFlowRate.cs
@@ -27,7 +27,7 @@ using System.Text;
 using System.Threading.Tasks;
 using BH.oM.Base;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     //public class ZoneVentilationDesignFlowRate : BHoMObject
     //{

--- a/OpenStudio_oM/ZoneHVACForcedAirUnits/ZoneHVACFourPipeFanCoil.cs
+++ b/OpenStudio_oM/ZoneHVACForcedAirUnits/ZoneHVACFourPipeFanCoil.cs
@@ -26,7 +26,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     //class ZoneHVACFourPipeFanCoil
     //{

--- a/OpenStudio_oM/ZoneHVACForcedAirUnits/ZoneHVACIdealLoadsAirSystem.cs
+++ b/OpenStudio_oM/ZoneHVACForcedAirUnits/ZoneHVACIdealLoadsAirSystem.cs
@@ -26,7 +26,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace BH.oM.OpenStudio
+namespace BH.oM.Adapters.OpenStudio
 {
     //class ZoneHVACIdealLoadsAirSystem
     //{


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->
  
### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #36

<!-- Add short description of what has been fixed -->
Namespace now compliant to `Adapters`.

Also, the build was failing due to 2 references to a missing method `BH.Engine.Environment.Create.Opening()`. I assumed they were an oversight that's been there for a while, so I replaced them. Since I didn't find any equivalent for "creating openings" in the Environment Engine, I replaced them with a Constructor invocation. Those are:
- in BH.Engine.Adapters.OpenStudio.Convert.ToOSM(), line 69
- in BH.Engine.Adapters.OpenStudio.Modify.OffsetOpening(), line 92

### Test files
<!-- Link to test files to validate the proposed changes -->
Proper testing left as TODO for code owners.

### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Namespaces now compliant: oM.Adapters.OpenStudio and oM.Engine.OpenStudio
- Corrected calls to a missing method `BH.Engine.Environment.Create.Opening()`

### Additional comments
<!-- As required -->
